### PR TITLE
Let users answer poll-like questions correctly

### DIFF
--- a/app/models/tasuku/taskables/question/answer.rb
+++ b/app/models/tasuku/taskables/question/answer.rb
@@ -18,6 +18,7 @@ module Tasuku
       request is: :question
 
       def correct?
+        return true if question.options.none?(&:correct?)
         votes.all? { |vote| vote.option.correct? }
       end
 

--- a/spec/models/tasuku/taskables/question/answer_spec.rb
+++ b/spec/models/tasuku/taskables/question/answer_spec.rb
@@ -61,6 +61,7 @@ module Tasuku
           expect(answer).not_to be_correct
         end
       end
+
       context 'one correct option' do
         it 'should return true if all votes are correct' do
           first_option.update_attributes!(correct: true)
@@ -73,10 +74,11 @@ module Tasuku
           expect(answer).not_to be_correct
         end
       end
+
       context 'no correct options' do
-        it 'should always return false' do
+        it 'should always return true' do
           answer = create :question_answer, options: [first_option]
-          expect(answer).not_to be_correct
+          expect(answer).to be_correct
         end
       end
     end


### PR DESCRIPTION
We might use questions as polls by setting no option to be correct. When this is
completed, though, the answers should be considered correct, not incorrect.
